### PR TITLE
docs(readme): standardize the flag format of rclone

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ yarn run tauri build
 
 添加自定义 Rclone 标志以获得最佳性能：
 
-- `--vfs-cache-mode full`：启用完整 VFS 缓存
-- `--buffer-size 256M`：增加缓冲区大小
-- `--transfers 10`：并发传输限制
+- `--vfs-cache-mode=full`：启用完整 VFS 缓存
+- `--buffer-size=256M`：增加缓冲区大小
+- `--transfers=10`：并发传输限制
 
 #### 系统托盘操作
 


### PR DESCRIPTION
出于一些奇怪的原因，我在windows上使用“空格”会报错，需要修改为“理论上更规范”的“=”才行。 我在查询rclone的文档后发现“=”似乎是适合自动化并避免出错的做法。