### PR TITLE
fix(firewall): handle localized rule status

### DIFF
--- a/src-tauri/src/cmd/firewall.rs
+++ b/src-tauri/src/cmd/firewall.rs
@@ -57,22 +57,23 @@ fn firewall_rule(verb: &str, port: Option<u16>) -> Result<bool, String> {
 }
 
 #[cfg(target_os = "windows")]
-fn rule_stdout() -> Result<Option<String>, String> {
-    let out = Command::new("netsh")
-        .args([
-            "advfirewall",
-            "firewall",
-            "show",
-            "rule",
-            &format!("name={RULE}"),
-        ])
+fn firewall_rule_exists(port: u16) -> Result<bool, String> {
+    let script = format!(
+        "try {{ $rules = (New-Object -ComObject HNetCfg.FwPolicy2).Rules; \
+         foreach ($rule in $rules) {{ if ($rule.Name -eq '{RULE}' -and $rule.Enabled \
+         -and $rule.Direction -eq 1 -and $rule.Action -eq 1 -and $rule.Protocol -eq 6 \
+         -and $rule.LocalPorts -eq '{port}') {{ exit 0 }} }}; exit 1 }} catch {{ exit 2 }}"
+    );
+    let status = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
         .creation_flags(0x08000000)
-        .output()
-        .map_err(|e| format!("netsh: {e}"))?;
-    if out.status.success() {
-        Ok(Some(String::from_utf8_lossy(&out.stdout).into()))
-    } else {
-        Ok(None)
+        .status()
+        .map_err(|e| format!("powershell: {e}"))?;
+    match status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        Some(code) => Err(format!("powershell exited with status {code}")),
+        None => Err("powershell terminated without an exit code".into()),
     }
 }
 
@@ -81,8 +82,8 @@ fn firewall_rule(_: &str, _: Option<u16>) -> Result<bool, String> {
     Ok(true)
 }
 #[cfg(not(target_os = "windows"))]
-fn rule_stdout() -> Result<Option<String>, String> {
-    Ok(None)
+fn firewall_rule_exists(_: u16) -> Result<bool, String> {
+    Ok(false)
 }
 
 #[tauri::command]
@@ -95,14 +96,7 @@ pub async fn check_firewall_rule(state: State<'_, AppState>) -> Result<bool, Str
         .openlist
         .port;
 
-    if let Some(out) = rule_stdout()? {
-        let rule_exists = out.contains(&format!("LocalPort: {port}"))
-            && out.contains("Action: Allow")
-            && out.contains("Protocol: TCP");
-        Ok(rule_exists)
-    } else {
-        Ok(false)
-    }
+    firewall_rule_exists(port)
 }
 
 #[tauri::command]
@@ -114,6 +108,10 @@ pub async fn add_firewall_rule(state: State<'_, AppState>) -> Result<bool, Strin
         .ok_or("read settings")?
         .openlist
         .port;
+
+    if firewall_rule_exists(port)? {
+        return Ok(true);
+    }
 
     let _ = firewall_rule("delete", None);
     firewall_rule("add", Some(port))

--- a/src-tauri/src/cmd/firewall.rs
+++ b/src-tauri/src/cmd/firewall.rs
@@ -59,10 +59,10 @@ fn firewall_rule(verb: &str, port: Option<u16>) -> Result<bool, String> {
 #[cfg(target_os = "windows")]
 fn firewall_rule_exists(port: u16) -> Result<bool, String> {
     let script = format!(
-        "try {{ $rules = (New-Object -ComObject HNetCfg.FwPolicy2).Rules; \
-         foreach ($rule in $rules) {{ if ($rule.Name -eq '{RULE}' -and $rule.Enabled \
-         -and $rule.Direction -eq 1 -and $rule.Action -eq 1 -and $rule.Protocol -eq 6 \
-         -and $rule.LocalPorts -eq '{port}') {{ exit 0 }} }}; exit 1 }} catch {{ exit 2 }}"
+        "try {{ $rules = (New-Object -ComObject HNetCfg.FwPolicy2).Rules; foreach ($rule in \
+         $rules) {{ if ($rule.Name -eq '{RULE}' -and $rule.Enabled -and $rule.Direction -eq 1 \
+         -and $rule.Action -eq 1 -and $rule.Protocol -eq 6 -and $rule.LocalPorts -eq '{port}') {{ \
+         exit 0 }} }}; exit 1 }} catch {{ exit 2 }}"
     );
     let status = Command::new("powershell")
         .args(["-NoProfile", "-NonInteractive", "-Command", &script])

--- a/src/components/dashboard/QuickActionsCard.vue
+++ b/src/components/dashboard/QuickActionsCard.vue
@@ -122,7 +122,7 @@ const router = useRouter()
 const message = useMessage()
 const appStore = useAppStore()
 const firewallEnabled = ref(false)
-const firewallLoading = ref(false)
+const firewallLoading = ref(isWindows)
 const { isCoreRunning, isCoreLoading } = storeToRefs(appStore)
 
 const toggleCore = async () => {
@@ -172,6 +172,8 @@ const checkFirewallStatus = async () => {
     firewallEnabled.value = await TauriAPI.firewall.check()
   } catch (error) {
     console.error('Failed to check firewall status:', error)
+  } finally {
+    firewallLoading.value = false
   }
 }
 
@@ -180,11 +182,11 @@ const toggleFirewallRule = async () => {
   try {
     firewallLoading.value = true
     if (firewallEnabled.value) {
-      await TauriAPI.firewall.remove()
+      if (!(await TauriAPI.firewall.remove())) throw new Error('netsh command failed')
       firewallEnabled.value = false
       message.success(t('dashboard.quickActions.firewall.removed'))
     } else {
-      await TauriAPI.firewall.add()
+      if (!(await TauriAPI.firewall.add())) throw new Error('netsh command failed')
       firewallEnabled.value = true
       message.success(t('dashboard.quickActions.firewall.added'))
     }


### PR DESCRIPTION
## Summary / 摘要

- Fix firewall status detection on localized Windows systems so the dashboard continues to show the actual rule state after navigating away and back.
  修复本地化 Windows 系统上的防火墙状态检测，使用户切换页面再返回后，主页仍显示规则的真实状态。
- Replace localized `netsh` text parsing with structured Windows Firewall COM properties for the rule name, enabled state, direction, action, protocol, and local port.
  使用结构化的 Windows 防火墙 COM 属性替代本地化的 `netsh` 文本解析，精确检查规则名称、启用状态、方向、动作、协议和本地端口。
- Distinguish matching rules, non-matching rules, and query failures so a query error cannot trigger a firewall write operation.
  区分规则匹配、规则不匹配和查询失败，防止查询错误触发防火墙写操作。
- Make repeated allow operations idempotent and honor backend operation failures in the UI.
  使重复放行操作具备幂等性，并让界面正确处理后端操作失败。
- Disable the firewall button while its initial state is being queried to avoid a mount-time race.
  在初始状态查询期间禁用防火墙按钮，避免组件挂载时的竞态操作。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #182

## Testing / 测试

- [ ] `go test ./...` (not applicable to this Tauri/Vue repository / 不适用于此 Tauri/Vue 仓库)
- [x] `vue-tsc --noEmit`
- [x] ESLint on the changed Vue component after excluding the checkout's existing CRLF/Prettier baseline mismatch.
      / 排除当前检出中既有的 CRLF/Prettier 基线差异后，对修改的 Vue 组件执行了 ESLint。
- [x] Prettier check on the changed Vue component while preserving the checkout's CRLF line endings.
      / 在保留当前检出 CRLF 换行符的情况下，对修改的 Vue 组件执行了 Prettier 检查。
- [x] Manual test / 手动测试:
  - Verified the Windows Firewall COM query returns distinct exit codes for a matching rule, a non-matching rule, and a query failure.
    验证 Windows 防火墙 COM 查询对规则匹配、规则不匹配和查询失败分别返回不同退出码。
  - Verified the query against the existing local `OpenList Core` rule without modifying firewall state.
    对本机现有的 `OpenList Core` 规则进行了只读查询验证，未修改防火墙状态。
  - Verified `git diff --check` and reviewed all firewall call sites.
    验证了 `git diff --check`，并复查了全部防火墙调用点。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [ ] Tests / 测试
- [x] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。