### PR TITLE
fix(mount): improve WebDAV write compatibility

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -43,7 +43,7 @@ async function getLatestRcloneVersion() {
 }
 
 // openlist version management
-let openlistVersion = 'v4.0.8'
+let openlistVersion = 'v4.2.4'
 
 async function getLatestOpenlistVersion() {
   try {
@@ -52,7 +52,7 @@ async function getLatestOpenlistVersion() {
       getFetchOptions(),
     )
     const data = await response.json()
-    openlistVersion = data.tag_name || 'v4.0.8'
+    openlistVersion = data.tag_name || 'v4.2.4'
     console.log(`Latest OpenList version: ${openlistVersion}`)
   } catch (error) {
     console.log('Error fetching latest OpenList version:', error.message)

--- a/src-tauri/src/cmd/rclone_mount.rs
+++ b/src-tauri/src/cmd/rclone_mount.rs
@@ -34,6 +34,45 @@ pub fn get_mount_process_id(remote_name: &str) -> String {
     format!("rclone_mount_{remote_name}_process")
 }
 
+fn ensure_vfs_write_cache(args: &mut Vec<String>) {
+    let has_cache_mode = args
+        .iter()
+        .any(|arg| arg == "--vfs-cache-mode" || arg.starts_with("--vfs-cache-mode="));
+    if !has_cache_mode {
+        args.push("--vfs-cache-mode=writes".into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_vfs_write_cache;
+
+    #[test]
+    fn adds_default_vfs_write_cache() {
+        let mut args = vec!["remote:".into(), "mount-point".into()];
+
+        ensure_vfs_write_cache(&mut args);
+
+        assert_eq!(args.last().unwrap(), "--vfs-cache-mode=writes");
+    }
+
+    #[test]
+    fn preserves_explicit_vfs_cache_mode() {
+        for cache_mode in [
+            vec!["--vfs-cache-mode=full".into()],
+            vec!["--vfs-cache-mode".into(), "off".into()],
+        ] {
+            let mut args = vec!["remote:".into(), "mount-point".into()];
+            args.extend(cache_mode);
+            let expected = args.clone();
+
+            ensure_vfs_write_cache(&mut args);
+
+            assert_eq!(args, expected);
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn get_libfuse_path() -> Option<String> {
     [
@@ -180,7 +219,8 @@ pub async fn mount_remote(
     let rclone_conf_path = get_rclone_config_path_with_custom(state)
         .map_err(|e| format!("Failed to get rclone config path: {e}"))?;
 
-    let args_vec = split_args_vec(config.args.clone());
+    let mut args_vec = split_args_vec(config.args.clone());
+    ensure_vfs_write_cache(&mut args_vec);
 
     let mount_point_opt = args_vec.iter().filter(|arg| !arg.starts_with('-')).nth(1);
 


### PR DESCRIPTION
## Summary / 摘要

- Default rclone WebDAV mounts to `--vfs-cache-mode=writes` when no cache mode is explicitly configured, enabling normal buffered writes while preserving user overrides.
  当用户未显式配置缓存模式时，rclone WebDAV 挂载默认使用 `--vfs-cache-mode=writes`，从而支持正常的缓冲写入，同时保留用户自定义设置。
- Apply the default at the shared mount entry point so both manual mounts and login auto-mounts, including existing configurations, receive the same behavior.
  在统一挂载入口应用该默认值，使手动挂载、登录自动挂载以及已有配置都获得一致行为。
- Update the fallback OpenList sidecar version to v4.2.4, the first release containing the 139Yun family-cloud path fix required for creating folders at the root.
  将 OpenList sidecar 回退版本更新至 v4.2.4，这是首个包含 139 家庭云根目录文件夹创建路径修复的版本。
- Add focused tests covering default cache injection and both supported explicit cache-mode argument forms.
  添加针对性测试，覆盖默认缓存注入以及两种受支持的显式缓存模式参数形式。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Closes #183
Closes #192

## Testing / 测试

- [ ] `go test ./...`
- [ ] Manual test / 手动测试:
- [x] `node --check scripts/prepare.js`
- [x] `git diff --check`
- [x] Verified the commit signature and reviewed the complete diff. / 已验证提交签名并完整复查差异。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [ ] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [x] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
