### PR TITLE
fix(mount): start core only for local remotes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ use tauri::Emitter;
 
 use crate::cmd::rclone_mount::{MountProcessInput, get_mount_process_id};
 use crate::conf::rclone::RcloneMountConfig;
+use crate::conf::rclone_config::RcloneConfigFile;
 
 #[tauri::command]
 async fn update_tray_menu(
@@ -178,11 +179,21 @@ async fn auto_mount_rclone_remotes_on_login(app_handle: &tauri::AppHandle) -> Re
         log::info!("No Rclone remotes configured for auto-mount on login");
         return Ok(());
     }
-    if !settings.openlist.auto_launch
-        && remotes_to_mount
-            .iter()
-            .any(|remote| is_local_openlist_url(&remote.url))
-    {
+    let has_local_remote = RcloneConfigFile::load_with_custom(app_state.clone())
+        .map(|config| {
+            remotes_to_mount.iter().any(|remote| {
+                config
+                    .remotes
+                    .get(&remote.name)
+                    .and_then(|remote| remote.options.get("url"))
+                    .is_some_and(|url| is_local_openlist_url(url))
+            })
+        })
+        .unwrap_or_else(|e| {
+            log::error!("Failed to load Rclone config before mounting remotes: {e}");
+            false
+        });
+    if !settings.openlist.auto_launch && has_local_remote {
         log::info!("Trying to auto-start OpenList Core before mounting local remotes");
         match start_openlist_core(app_state.clone()).await {
             Ok(_) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,10 +197,14 @@ async fn auto_mount_rclone_remotes_on_login(app_handle: &tauri::AppHandle) -> Re
         log::info!("Trying to auto-start OpenList Core before mounting local remotes");
         match start_openlist_core(app_state.clone()).await {
             Ok(_) => {
-                log::info!("OpenList Core process started successfully before mounting local remotes");
+                log::info!(
+                    "OpenList Core process started successfully before mounting local remotes"
+                );
             }
             Err(e) => {
-                log::error!("Failed to start OpenList Core process before mounting local remotes: {e}");
+                log::error!(
+                    "Failed to start OpenList Core process before mounting local remotes: {e}"
+                );
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,33 +104,6 @@ fn is_local_openlist_url(url: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::is_local_openlist_url;
-
-    #[test]
-    fn identifies_local_openlist_urls() {
-        for url in [
-            "http://localhost:5244/dav/1",
-            "https://127.0.0.1:5244/dav/1",
-            "http://[::1]:5244/dav/1",
-        ] {
-            assert!(is_local_openlist_url(url));
-        }
-    }
-
-    #[test]
-    fn rejects_remote_openlist_urls() {
-        for url in [
-            "https://openlist.example.com/dav/1",
-            "http://192.168.1.10:5244/dav/1",
-            "not a url",
-        ] {
-            assert!(!is_local_openlist_url(url));
-        }
-    }
-}
-
 async fn auto_start_openlist_core_on_login(app_handle: &tauri::AppHandle) -> Result<(), String> {
     let app_state = app_handle.state::<AppState>();
     let settings = app_state
@@ -408,4 +381,31 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_local_openlist_url;
+
+    #[test]
+    fn identifies_local_openlist_urls() {
+        for url in [
+            "http://localhost:5244/dav/1",
+            "https://127.0.0.1:5244/dav/1",
+            "http://[::1]:5244/dav/1",
+        ] {
+            assert!(is_local_openlist_url(url));
+        }
+    }
+
+    #[test]
+    fn rejects_remote_openlist_urls() {
+        for url in [
+            "https://openlist.example.com/dav/1",
+            "http://192.168.1.10:5244/dav/1",
+            "not a url",
+        ] {
+            assert!(!is_local_openlist_url(url));
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use tauri::Manager;
+use url::{Host, Url};
 
 mod cmd;
 mod conf;
@@ -91,6 +92,44 @@ fn setup_background_update_checker(app_handle: &tauri::AppHandle) {
     });
 }
 
+fn is_local_openlist_url(url: &str) -> bool {
+    Url::parse(url)
+        .map(|url| match url.host() {
+            Some(Host::Domain("localhost")) => true,
+            Some(Host::Ipv4(ip)) => ip.is_loopback(),
+            Some(Host::Ipv6(ip)) => ip.is_loopback(),
+            _ => false,
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_local_openlist_url;
+
+    #[test]
+    fn identifies_local_openlist_urls() {
+        for url in [
+            "http://localhost:5244/dav/1",
+            "https://127.0.0.1:5244/dav/1",
+            "http://[::1]:5244/dav/1",
+        ] {
+            assert!(is_local_openlist_url(url));
+        }
+    }
+
+    #[test]
+    fn rejects_remote_openlist_urls() {
+        for url in [
+            "https://openlist.example.com/dav/1",
+            "http://192.168.1.10:5244/dav/1",
+            "not a url",
+        ] {
+            assert!(!is_local_openlist_url(url));
+        }
+    }
+}
+
 async fn auto_start_openlist_core_on_login(app_handle: &tauri::AppHandle) -> Result<(), String> {
     let app_state = app_handle.state::<AppState>();
     let settings = app_state
@@ -138,6 +177,21 @@ async fn auto_mount_rclone_remotes_on_login(app_handle: &tauri::AppHandle) -> Re
     if remotes_to_mount.is_empty() {
         log::info!("No Rclone remotes configured for auto-mount on login");
         return Ok(());
+    }
+    if !settings.openlist.auto_launch
+        && remotes_to_mount
+            .iter()
+            .any(|remote| is_local_openlist_url(&remote.url))
+    {
+        log::info!("Trying to auto-start OpenList Core before mounting local remotes");
+        match start_openlist_core(app_state.clone()).await {
+            Ok(_) => {
+                log::info!("OpenList Core process started successfully before mounting local remotes");
+            }
+            Err(e) => {
+                log::error!("Failed to start OpenList Core process before mounting local remotes: {e}");
+            }
+        }
     }
     for remote in remotes_to_mount {
         log::info!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,15 +139,6 @@ async fn auto_mount_rclone_remotes_on_login(app_handle: &tauri::AppHandle) -> Re
         log::info!("No Rclone remotes configured for auto-mount on login");
         return Ok(());
     }
-    log::info!("Trying to auto-start OpenList Core before mounting remotes");
-    match start_openlist_core(app_state.clone()).await {
-        Ok(_) => {
-            log::info!("OpenList Core process started successfully before mounting remotes");
-        }
-        Err(e) => {
-            log::error!("Failed to start OpenList Core process before mounting remotes: {e}");
-        }
-    }
     for remote in remotes_to_mount {
         log::info!(
             "Auto-mount on login is enabled for remote '{}', attempting to mount",


### PR DESCRIPTION
## Summary / 摘要

- Start the local OpenList Core before automatic Rclone mounts only when an enabled mount targets a loopback WebDAV endpoint.
  仅当已启用的自动挂载目标为回环 WebDAV 端点时，才在挂载前启动本地 OpenList Core。
- Keep remote OpenList mounts independent from the local Core auto-launch setting.
  使远端 OpenList 挂载不再受本地 Core 自动启动行为影响。
- Read each remote URL from the effective rclone configuration so custom or externally edited configurations are handled correctly.
  从实际生效的 Rclone 配置中读取各 remote 的 URL，正确支持自定义或外部修改过的配置。
- Add coverage for localhost, IPv4 loopback, IPv6 loopback, remote, and invalid URLs.
  为 localhost、IPv4 回环、IPv6 回环、远端及无效 URL 添加覆盖。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Closes #195

## Testing / 测试

- [x] `git diff --check main...HEAD`
- [ ] `cargo fmt --check`
      / 未执行：本机 rustup 未安装 Rust toolchain。
- [ ] Related Rust unit tests
      / 未执行：本机 rustup 未安装 Rust toolchain。
- [x] Static review of local, remote, mixed remote, and `auto_launch` startup paths.
      / 已静态复查本地、远端、混合 remote 及 `auto_launch` 启动路径。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [ ] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Claude

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。